### PR TITLE
Add landing page for XROBO AI feature navigation

### DIFF
--- a/manual/img/ai/ball-follow.svg
+++ b/manual/img/ai/ball-follow.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 260">
+  <defs>
+    <linearGradient id="grad-ball" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#11998e" />
+      <stop offset="100%" stop-color="#38ef7d" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="260" rx="24" fill="url(#grad-ball)" />
+  <circle cx="140" cy="140" r="52" fill="#ffffff" opacity="0.9" />
+  <circle cx="140" cy="140" r="24" fill="#11998e" opacity="0.6" />
+  <path d="M220 140h72" stroke="#ffffff" stroke-width="12" stroke-linecap="round" opacity="0.8" />
+  <path d="M252 116l40 24-40 24z" fill="#ffffff" opacity="0.9" />
+  <text x="200" y="64" fill="#ffffff" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="28" font-weight="600" text-anchor="middle">공따라가기</text>
+</svg>

--- a/manual/img/ai/color-detect.svg
+++ b/manual/img/ai/color-detect.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 260">
+  <defs>
+    <linearGradient id="grad-color" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff9966" />
+      <stop offset="100%" stop-color="#ff5e62" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="260" rx="24" fill="url(#grad-color)" />
+  <circle cx="200" cy="150" r="72" fill="#ffffff" opacity="0.18" />
+  <g transform="translate(200 140)" fill="none" stroke="#ffffff" stroke-width="12" stroke-linecap="round">
+    <path d="M0 -72A72 72 0 0 1 62 36" />
+    <path d="M62 36A72 72 0 0 1 -62 36" opacity="0.7" />
+    <path d="M-62 36A72 72 0 0 1 0 -72" opacity="0.4" />
+  </g>
+  <circle cx="200" cy="140" r="24" fill="#ffffff" />
+  <text x="200" y="64" fill="#ffffff" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="28" font-weight="600" text-anchor="middle">색상감별</text>
+</svg>

--- a/manual/img/ai/gyro-sensor.svg
+++ b/manual/img/ai/gyro-sensor.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 260">
+  <defs>
+    <linearGradient id="grad-gyro" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f7971e" />
+      <stop offset="100%" stop-color="#ffd200" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="260" rx="24" fill="url(#grad-gyro)" />
+  <g transform="translate(200 140)" fill="none" stroke="#ffffff" stroke-width="10" stroke-linecap="round" opacity="0.9">
+    <circle r="72" opacity="0.4" />
+    <path d="M-72 0h144" />
+    <path d="M0 -72v144" opacity="0.7" />
+    <path d="M-48 -48l96 96" opacity="0.5" />
+    <path d="M-48 48l96 -96" opacity="0.5" />
+  </g>
+  <circle cx="200" cy="140" r="18" fill="#ffffff" opacity="0.9" />
+  <text x="200" y="64" fill="#ffffff" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="28" font-weight="600" text-anchor="middle">자이로센서</text>
+</svg>

--- a/manual/img/ai/hand-gesture.svg
+++ b/manual/img/ai/hand-gesture.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 260">
+  <defs>
+    <linearGradient id="grad-hand" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f46b45" />
+      <stop offset="100%" stop-color="#eea849" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="260" rx="24" fill="url(#grad-hand)" />
+  <g fill="none" stroke="#ffffff" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
+    <path d="M148 176c32 40 72 40 104 0 16-20 16-56-8-80-6-6-12-10-20-12v-20c0-10-8-18-18-18s-18 8-18 18v16-26c0-10-8-18-18-18s-18 8-18 18v34-22c0-10-8-18-18-18s-18 8-18 18v74" />
+  </g>
+  <text x="200" y="64" fill="#ffffff" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="28" font-weight="600" text-anchor="middle">손모양감지</text>
+</svg>

--- a/manual/img/ai/line-follow.svg
+++ b/manual/img/ai/line-follow.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 260">
+  <defs>
+    <linearGradient id="grad-line" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f953c6" />
+      <stop offset="100%" stop-color="#b91d73" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="260" rx="24" fill="url(#grad-line)" />
+  <path d="M72 188c28-44 64-80 128-80s100 36 128 80" fill="none" stroke="#ffffff" stroke-width="12" stroke-linecap="round" opacity="0.85" />
+  <path d="M132 92l24-24 24 24" fill="none" stroke="#ffffff" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+  <text x="200" y="64" fill="#ffffff" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="28" font-weight="600" text-anchor="middle">라인따라가기</text>
+</svg>

--- a/manual/img/ai/live-coding.svg
+++ b/manual/img/ai/live-coding.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 260">
+  <defs>
+    <linearGradient id="grad-live" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6a11cb" />
+      <stop offset="100%" stop-color="#2575fc" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="260" rx="24" fill="url(#grad-live)" />
+  <g fill="#ffffff" opacity="0.9">
+    <rect x="88" y="78" width="224" height="132" rx="16" fill="#ffffff" opacity="0.15" />
+    <path d="M156 110h24v80h-24zM212 110l56 40-56 40z" fill="#ffffff" />
+  </g>
+  <text x="200" y="64" fill="#ffffff" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="28" font-weight="600" text-anchor="middle">라이브 코딩</text>
+</svg>

--- a/manual/img/ai/number-card.svg
+++ b/manual/img/ai/number-card.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 260">
+  <defs>
+    <linearGradient id="grad-number" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#654ea3" />
+      <stop offset="100%" stop-color="#eaafc8" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="260" rx="24" fill="url(#grad-number)" />
+  <g fill="#ffffff" opacity="0.92">
+    <rect x="120" y="84" width="72" height="96" rx="12" opacity="0.8" />
+    <rect x="208" y="84" width="72" height="96" rx="12" />
+    <text x="156" y="150" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="48" font-weight="700" text-anchor="middle">5</text>
+    <text x="244" y="150" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="48" font-weight="700" text-anchor="middle">8</text>
+  </g>
+  <text x="200" y="64" fill="#ffffff" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="28" font-weight="600" text-anchor="middle">숫자카드읽기</text>
+</svg>

--- a/manual/img/ai/voice-command.svg
+++ b/manual/img/ai/voice-command.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 260">
+  <defs>
+    <linearGradient id="grad-voice" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00b4db" />
+      <stop offset="100%" stop-color="#0083b0" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="260" rx="24" fill="url(#grad-voice)" />
+  <g fill="none" stroke="#ffffff" stroke-width="14" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <rect x="170" y="82" width="60" height="96" rx="30" />
+    <path d="M200 178v32" />
+    <path d="M156 162c8 24 24 40 44 40s36-16 44-40" opacity="0.7" />
+    <path d="M128 150c12 40 32 68 72 68s60-28 72-68" opacity="0.45" />
+  </g>
+  <text x="200" y="64" fill="#ffffff" font-family="'IBM Plex Sans KR', 'Noto Sans KR', sans-serif" font-size="28" font-weight="600" text-anchor="middle">음성명령</text>
+</svg>

--- a/manual/src/ai.css
+++ b/manual/src/ai.css
@@ -1,0 +1,88 @@
+body {
+  background: #f4f7fb;
+  color: #1f2933;
+  font-family: 'IBM Plex Sans KR', 'Noto Sans KR', sans-serif;
+  margin: 0;
+}
+
+.header {
+  text-align: center;
+  padding: 120px 16px 48px;
+}
+
+.header h1 {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.12em;
+}
+
+.header p {
+  font-size: 1.1rem;
+  color: #52606d;
+}
+
+.button-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 24px 120px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 28px;
+}
+
+.feature-card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  border-radius: 24px;
+  overflow: hidden;
+  background: #ffffff;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.feature-card img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.feature-card span {
+  display: block;
+  padding: 20px 24px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #1f2933;
+  text-align: center;
+  background: #ffffff;
+}
+
+.feature-card:hover,
+.feature-card:focus {
+  transform: translateY(-8px);
+  box-shadow: 0 28px 56px rgba(15, 23, 42, 0.2);
+}
+
+@media (max-width: 1200px) {
+  .button-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .header {
+    padding-top: 96px;
+  }
+  .button-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .header h1 {
+    font-size: 2.2rem;
+  }
+  .button-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/manual/xrobo-ai.html
+++ b/manual/xrobo-ai.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>XROBO AI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="src/ai.css">
+</head>
+<body>
+  <header class="header">
+    <h1>XROBO AI</h1>
+    <p>한눈에 살펴보는 XROBO AI 실습 모음. 원하는 기능을 선택해 자세한 안내 페이지로 이동해 보세요.</p>
+  </header>
+
+  <main class="button-grid" aria-label="XROBO AI 기능 바로가기">
+    <a class="feature-card" href="#live-coding" aria-label="라이브 코딩 페이지로 이동">
+      <img src="img/ai/live-coding.svg" alt="라이브 코딩 대표 이미지">
+      <span>라이브 코딩</span>
+    </a>
+    <a class="feature-card" href="#color-detect" aria-label="색상감별 페이지로 이동">
+      <img src="img/ai/color-detect.svg" alt="색상감별 대표 이미지">
+      <span>색상감별</span>
+    </a>
+    <a class="feature-card" href="#voice-command" aria-label="음성명령 페이지로 이동">
+      <img src="img/ai/voice-command.svg" alt="음성명령 대표 이미지">
+      <span>음성명령</span>
+    </a>
+    <a class="feature-card" href="#gyro-sensor" aria-label="자이로센서 페이지로 이동">
+      <img src="img/ai/gyro-sensor.svg" alt="자이로센서 대표 이미지">
+      <span>자이로센서</span>
+    </a>
+    <a class="feature-card" href="#ball-follow" aria-label="공따라가기 페이지로 이동">
+      <img src="img/ai/ball-follow.svg" alt="공따라가기 대표 이미지">
+      <span>공따라가기</span>
+    </a>
+    <a class="feature-card" href="#line-follow" aria-label="라인따라가기 페이지로 이동">
+      <img src="img/ai/line-follow.svg" alt="라인따라가기 대표 이미지">
+      <span>라인따라가기</span>
+    </a>
+    <a class="feature-card" href="#number-card" aria-label="숫자카드읽기 페이지로 이동">
+      <img src="img/ai/number-card.svg" alt="숫자카드읽기 대표 이미지">
+      <span>숫자카드읽기</span>
+    </a>
+    <a class="feature-card" href="#hand-gesture" aria-label="손모양감지 페이지로 이동">
+      <img src="img/ai/hand-gesture.svg" alt="손모양감지 대표 이미지">
+      <span>손모양감지</span>
+    </a>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an XROBO AI landing page with a grid of eight feature links
- create dedicated styling for the feature grid layout and hover effects
- add illustrative SVG thumbnails for each AI feature button

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917f227f8b483308d6b73691c333ab0)